### PR TITLE
Replace ifcfg with ifaddr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,5 @@ setup(
         "Service Discovery",
         "mDNS",
     ],
-    install_requires=["ifcfg", "six"],
+    install_requires=["ifaddr", "six"],
 )

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -34,7 +34,7 @@ import threading
 import time
 from functools import reduce
 
-import ifcfg
+import ifaddr
 from six import binary_type, indexbytes, int2byte, iteritems, text_type
 from six.moves import xrange
 
@@ -1735,7 +1735,14 @@ if "ANDROID_ARGUMENT" in os.environ:
 
 else:
      def get_network_interfaces():
-         return ifcfg.interfaces().values()
+         interfaces = []
+         for adapter in ifaddr.get_adapters():
+             for ip in adapter.ips:
+                 interfaces.append({
+                     "inet": ip.ip if ip.is_IPv4 else "",
+                     "inet6": ip.ip if ip.is_IPv6 else ""
+                 })
+         return interfaces
 
 
 def get_all_addresses():


### PR DESCRIPTION
This replaces the `get_network_interfaces` code with an implementation that uses the _ifaddr_ module, instead of _ifcfg_. The replacement is also Python 2 compatible, and it works in an environment without the `ifconfig` or `ip` commands, such as a Flatpak runtime.