### PR TITLE
Use a threading Event for _GLOBAL_DONE variable to give better interruption

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     description="Pure Python Multicast DNS Service Discovery Library "
     "(Bonjour/Avahi compatible)",
     long_description=readme,
-    author="Paul Scott-Murphy, William McBrine, Jakub Stasiak, Jamie Alexandre",
+    author="Paul Scott-Murphy, William McBrine, Jakub Stasiak, Jamie Alexandre, Richard Tibbles",
     url="https://github.com/learningequality/python-zeroconf",
     py_modules=["zeroconf", "enum_compat"],
     platforms=["unix", "linux", "osx"],


### PR DESCRIPTION
Allows for easier interruption of the child threads by using a 0.1 second wait when checking for whether `_GLOBAL_DONE` has been triggered or not.

Fixes https://github.com/learningequality/kolibri/issues/6809

After making this change, Kolibri would shut down using the script in the issue above mostly in '1 second', with very little variance.

Main open question is whether this 0.1 second wait on every loop will cause any issues?

Noting that this is the identical strategy we use in our job checker threads in Kolibri that allow them to shutdown more promptly.