### PR TITLE
`_GLOBAL_DONE` wait time tuning

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1796,6 +1796,9 @@ def get_errno(e):
     assert isinstance(e, socket.error)
     return e.args[0]
 
+def get_global_done_wait_time():
+    wait_time = os.getenv('PYTHON_ZEROCONF_GLOBAL_DONE_WAIT_TIME')
+    return float(wait_time) if wait_time else 0.01
 
 class Zeroconf(QuietLogger):
 
@@ -1868,7 +1871,8 @@ class Zeroconf(QuietLogger):
 
     @property
     def done(self):
-        return self._GLOBAL_DONE.wait(0.1)
+        wait_time = get_global_done_wait_time()
+        return self._GLOBAL_DONE.wait(wait_time)
 
     def wait(self, timeout):
         """Calling thread waits for a given number of milliseconds or

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1798,7 +1798,7 @@ def get_errno(e):
 
 def get_global_done_wait_time():
     wait_time = os.getenv('PYTHON_ZEROCONF_GLOBAL_DONE_WAIT_TIME')
-    return float(wait_time) if wait_time else 0.01
+    return float(wait_time) if wait_time else 0.001
 
 class Zeroconf(QuietLogger):
 


### PR DESCRIPTION
#### Context
In #6, @rtibbles asks:

> Main open question is whether this 0.1 second wait on every loop will cause any issues?

Unfortunately, the answer seems to be "yes".  As you will find over the course of reading this PR, by quasi-scientific analysis we can see that this particular wait time seems to cause peer discovery to be very unreliable.  Thankfully, by tuning the wait time to 1ms, it appears that we can get reliable discovery and similarly short exit times.

#### Description
This change is intended to find a better balance between reliable discoverability and reasonable exit times.  It does two things:
- Changes the default `_GLOBAL_DONE` wait time from 100 ms to 1 ms
- Allows the `_GLOBAL_DONE` wait time to be set via an environment variable called `PYTHON_ZEROCONF_GLOBAL_DONE_WAIT_TIME`

#### How I tested this
I set my CPU frequency to 1.6 GHz and disabled throttling.

Then, I opened two shells:
- one to log the stability of zeroconf peer discovery
- one to log the exit times for a given wait time, which also conveniently served to simulate a peer registering and unregistering from zeroconf over and over again. 

##### Shell A: monitoring peer discovery success
In this shell, I started a Kolibri instance like this:
```
PYTHON_ZEROCONF_GLOBAL_DONE_WAIT_TIME=0.001 KOLIBRI_HOME=~/.kolibri-peer kolibri start --port 8001 --foreground
```

##### Shell B: monitoring exit times
In this shell, I monitored the stopping times by adapting @benjaoming's little script from [this Kolibri PR](https://github.com/learningequality/kolibri/issues/6809) to try different wait times, like this:
```
for i in {1..200} 
do
  PYTHON_ZEROCONF_GLOBAL_DONE_WAIT_TIME=0.001 kolibri start > /dev/null 2>&1
  START_TIME=$SECONDS
  kolibri stop > /dev/null 2>&1
  ELAPSED_TIME=$(($SECONDS - $START_TIME))
  echo "$ELAPSED_TIME"
done
```

#### Results
([spreadsheet here](https://docs.google.com/spreadsheets/d/1gzBzTUQma4T9I9zkXCjZ6xfTcLNHb6V9e6SlqRxSmhI/edit?usp=sharing))
|   | **mean exit time (s)** | **exits under 5 s** | **exits under 9 s** | **exits under 15s** | **% discovery success** | **# discoveries** | **# tries** |
| --- | --- | --- | --- | --- | --- | --- | --- |
|  **100 ms** | 2.59 | 98.15% | 98.15% | 100.00% | 7.41% | 4 | 54 |
|  **10 ms** | 4.17 | 75.00% | 83.51% | 100.00% | 61.17% | 115 | 188 |
|  **1 ms** | 3.32 | 98.23% | 99.12% | 100.00% | 100.00% | 113 | 113 |

As you can see here, while the original wait time of 100 ms produces the shortest mean exit time, only 7.4% of discoveries are successful.

For 10 ms, we get an improved discovery success rate of 61.2%, but 25% of exits take over 5s, and many of these are ~10s.  

Setting the wait time to 1 ms gives a 100% discovery success rate with exit times comparable to those achieved with the 100 ms wait time.

##### Note on CPU frequency
For the results in the table above, the CPU frequency was set to 1.6 GHz with throttling disabled.

I also did some less scientific testing of the 1 ms wait time at 0.5 GHz to simulate slower devices, and found that exit times were consistently ~ 10 seconds, pretty well ([under 30s](https://github.com/learningequality/kolibri/issues/6809)).