### PR TITLE
Track all requested interfaces, as well as ones actually attached

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,11 @@ See examples directory for more.
 Changelog
 =========
 
+0.19.15
+-------
+- Track all requested broadcast interfaces in addition to those successfully attached
+
+
 0.19.14
 -------
 - Exclude addresses starting with "169.254" from the list returned by get_all_addresses()

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -51,7 +51,7 @@ import enum_compat as enum
 
 __author__ = "Paul Scott-Murphy, William McBrine"
 __maintainer__ = "Learning Equality <info@learningequality.org>"
-__version__ = "0.19.14"
+__version__ = "0.19.15"
 __license__ = "LGPL"
 
 


### PR DESCRIPTION
- Keeps `interfaces` list equal to the requested interfaces
- Tracks separately the interfaces which successfully attached