### PR TITLE
Match service type with record name ending

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,10 +101,13 @@ See examples directory for more.
 Changelog
 =========
 
+0.19.16
+-------
+- Fix issue preventing TXT record updates from `ServiceBrowser`
+
 0.19.15
 -------
 - Track all requested broadcast interfaces in addition to those successfully attached
-
 
 0.19.14
 -------

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -51,7 +51,7 @@ import enum_compat as enum
 
 __author__ = "Paul Scott-Murphy, William McBrine"
 __maintainer__ = "Learning Equality <info@learningequality.org>"
-__version__ = "0.19.15"
+__version__ = "0.19.16"
 __license__ = "LGPL"
 
 

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1386,6 +1386,11 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
 
         Updates information required by browser in the Zeroconf cache."""
 
+        # if the record name does not end with the service type we're listening for,
+        # we'll ignore the update
+        if not record.name.endswith(self.type):
+            return
+
         def enqueue_callback(state_change, name):
             self._handlers_to_call.append(
                 lambda zeroconf: self._service_state_changed.fire(
@@ -1396,7 +1401,7 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
                 )
             )
 
-        if record.type == _TYPE_PTR and record.name == self.type:
+        if record.type == _TYPE_PTR:
             expired = record.is_expired(now)
             service_key = record.alias.lower()
             try:
@@ -1417,7 +1422,7 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
             if expires < self.next_time:
                 self.next_time = expires
 
-        elif record.type == _TYPE_TXT and record.name == self.type:
+        elif record.type == _TYPE_TXT:
             assert isinstance(record, DNSText)
             expired = record.is_expired(now)
             if not expired:


### PR DESCRIPTION
## Observed behavior
In Kolibri, when an instance's information is updated, the instance was properly broadcasting that, but the event wasn't being handled by other instances. I confirmed that instance was properly broadcasting updated information.

## Solution
The issue appeared to be that the `ServiceBrowser`, which accepts a specific service type to listen for, was performing an equality comparing on the updated record's name with the service type. But the record name should only end with the service type, and shouldn't match exactly, since there can be multiple devices of the same service on a network.